### PR TITLE
Fix weekday number fill

### DIFF
--- a/gen_calendar.py
+++ b/gen_calendar.py
@@ -354,6 +354,8 @@ class Calendar(object):
                 tp = self.picture.textPath(" %d" % (d.day,))
                 tp.setAttribute('xlink:href', weekId(d, '#'))
                 t = self.picture.text(None)
+                t.setAttribute('fill', 'black')
+                t.setAttribute('stroke', 'none')
                 t.appendChild(tp)
                 f.appendChild(t)
 


### PR DESCRIPTION
The letters were stroked, but not filled. This sets the attributes explicitly on each label.
